### PR TITLE
Simplify bound checks. Always keep the player inside the screen

### DIFF
--- a/game.py
+++ b/game.py
@@ -324,11 +324,11 @@ def main(screen, playerCount, ballSpeed, playerSpeed):
 
         # Actually moves the players if a key is pressed
         # First player
-        if sPressed and ypos1 <= screenHeight - playerSpeed - (playerHeight // 2):
+        if sPressed and ypos1 <= screenHeight - playerSpeed - playerHeight:
             ypos1 += playerSpeed
             curRects[0] = updatePos(xpos1, ypos1, lastRects[0], screen, playerImg)
             lastRects[0] = curRects[0]
-        if wPressed and ypos1 >= 0 + playerSpeed - (playerHeight // 2):
+        if wPressed and ypos1 >= playerSpeed:
             ypos1 -= playerSpeed
             curRects[0] = updatePos(xpos1, ypos1, lastRects[0], screen, playerImg)
             lastRects[0] = curRects[0]


### PR DESCRIPTION
I don't think we're supposed to move the player until half the player image is outside the screen.
With this PR, the player stays inside the screen all the time, and the position checks that run on every tick are simplified.